### PR TITLE
Make javascript compatible with CSP

### DIFF
--- a/src/Echo511/Plupload/templates/control/plupload.latte
+++ b/src/Echo511/Plupload/templates/control/plupload.latte
@@ -2,7 +2,7 @@
     <p>Your browser doesn't have Flash, Silverlight or HTML5 support.</p>
 </div>
 
-<script type="text/javascript">	
+<script type="text/javascript" n:nonce>	
 $(function() {
     $("#{$id|noescape}uploader").plupload({
         runtimes : 'html5',


### PR DESCRIPTION
n:nonce macro is important when CSP is used and only way that direct JS is gona work is with nonce attribute (witch macro provide). It harmless otherwise.